### PR TITLE
Feature/create information token

### DIFF
--- a/Poort8.Ishare.Core.Tests/AuthenticationServiceTests.cs
+++ b/Poort8.Ishare.Core.Tests/AuthenticationServiceTests.cs
@@ -85,7 +85,7 @@ public class AuthenticationServiceTests
         var authenticationService = new AuthenticationService(LoggerMock.Object, ConfigMock.Object, HttpClientFactoryMock.Object, MemoryCacheMock.Object, CertificateProviderMock.Object);
         var obje = new { test = "testValue" };
         var additionalClaims = new List<Claim> { new Claim("testClaim", JsonSerializer.Serialize(obje), JsonClaimValueTypes.Json) };
-        var informationToken = authenticationService.CreateInformationToken(null, additionalClaims);
+        var informationToken = authenticationService.CreateTokenWithClaims(null, additionalClaims);
         authenticationService.ValidateToken("EU.EORI.NL888888881", informationToken, 30, true, false);
 
         var handler = new JwtSecurityTokenHandler();

--- a/Poort8.Ishare.Core.Tests/AuthenticationServiceTests.cs
+++ b/Poort8.Ishare.Core.Tests/AuthenticationServiceTests.cs
@@ -80,7 +80,7 @@ public class AuthenticationServiceTests
     }
 
     [TestMethod]
-    public void TestCreateAndValidateInformationTokenSuccess()
+    public void TestCreateAndValidateTokenWithClaimsSuccess()
     {
         var authenticationService = new AuthenticationService(LoggerMock.Object, ConfigMock.Object, HttpClientFactoryMock.Object, MemoryCacheMock.Object, CertificateProviderMock.Object);
         var obje = new { test = "testValue" };

--- a/Poort8.Ishare.Core.Tests/Poort8.Ishare.Core.Tests.csproj
+++ b/Poort8.Ishare.Core.Tests/Poort8.Ishare.Core.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Poort8.Ishare.Core/AuthenticationService.cs
+++ b/Poort8.Ishare.Core/AuthenticationService.cs
@@ -41,7 +41,7 @@ public class AuthenticationService : IAuthenticationService
         return CreateToken(audience, 3600);
     }
 
-    public string CreateInformationToken(string audience, List<Claim> additionalClaims)
+    public string CreateTokenWithClaims(string? audience, IReadOnlyList<Claim> additionalClaims)
     {
         return CreateToken(audience, additionalClaims: additionalClaims);
     }
@@ -51,13 +51,13 @@ public class AuthenticationService : IAuthenticationService
         return CreateToken(audience, expSeconds);
     }
 
-    private string CreateToken(string audience, int expSeconds = 30, List<Claim> additionalClaims = null)
+    private string CreateToken(string? audience, int expSeconds = 30, IReadOnlyList<Claim>? additionalClaims = null)
     {
         var claims = new ClaimsIdentity();
         claims.AddClaim(new Claim("sub", _clientId));
         claims.AddClaim(new Claim("jti", Guid.NewGuid().ToString()));
 
-        if (additionalClaims != null)
+        if (additionalClaims is not null)
         {
             claims.AddClaims(additionalClaims);
         }

--- a/Poort8.Ishare.Core/AuthenticationService.cs
+++ b/Poort8.Ishare.Core/AuthenticationService.cs
@@ -38,14 +38,29 @@ public class AuthenticationService : IAuthenticationService
 
     public string CreateAccessToken(string audience)
     {
-        return CreateClientAssertion(audience, 3600);
+        return CreateToken(audience, 3600);
+    }
+
+    public string CreateInformationToken(string audience, List<Claim> additionalClaims)
+    {
+        return CreateToken(audience, additionalClaims: additionalClaims);
     }
 
     public string CreateClientAssertion(string audience, int expSeconds = 30)
     {
+        return CreateToken(audience, expSeconds);
+    }
+
+    private string CreateToken(string audience, int expSeconds = 30, List<Claim> additionalClaims = null)
+    {
         var claims = new ClaimsIdentity();
         claims.AddClaim(new Claim("sub", _clientId));
         claims.AddClaim(new Claim("jti", Guid.NewGuid().ToString()));
+
+        if (additionalClaims != null)
+        {
+            claims.AddClaims(additionalClaims);
+        }
 
         var tokenHandler = new JwtSecurityTokenHandler();
         var token = tokenHandler.CreateJwtSecurityToken(

--- a/Poort8.Ishare.Core/IAuthenticationService.cs
+++ b/Poort8.Ishare.Core/IAuthenticationService.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.Extensions.Primitives;
+﻿using System.Security.Claims;
+using Microsoft.Extensions.Primitives;
 
 namespace Poort8.Ishare.Core;
 
 public interface IAuthenticationService
 {
     string CreateAccessToken(string audience);
+    string CreateInformationToken(string audience, List<Claim> additionalClaims);
     string CreateClientAssertion(string audience, int expSeconds = 30);
     void ValidateAuthorizationHeader(string validIssuer, StringValues authorizationHeader);
     void ValidateAccessToken(string validIssuer, string accessToken);

--- a/Poort8.Ishare.Core/IAuthenticationService.cs
+++ b/Poort8.Ishare.Core/IAuthenticationService.cs
@@ -6,7 +6,7 @@ namespace Poort8.Ishare.Core;
 public interface IAuthenticationService
 {
     string CreateAccessToken(string audience);
-    string CreateInformationToken(string audience, List<Claim> additionalClaims);
+    string CreateTokenWithClaims(string audience, IReadOnlyList<Claim> additionalClaims);
     string CreateClientAssertion(string audience, int expSeconds = 30);
     void ValidateAuthorizationHeader(string validIssuer, StringValues authorizationHeader);
     void ValidateAccessToken(string validIssuer, string accessToken);

--- a/Poort8.Ishare.Core/Poort8.Ishare.Core.csproj
+++ b/Poort8.Ishare.Core/Poort8.Ishare.Core.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.17.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.18.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added CreateInformationToken to the IAuthenticationService to create an information token with additional claims. Fixed validity of 30 seconds.