### PR TITLE
Feature/nullable audience in token

### DIFF
--- a/Poort8.Ishare.Core.Tests/Poort8.Ishare.Core.Tests.csproj
+++ b/Poort8.Ishare.Core.Tests/Poort8.Ishare.Core.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/Poort8.Ishare.Core/IAuthenticationService.cs
+++ b/Poort8.Ishare.Core/IAuthenticationService.cs
@@ -6,7 +6,7 @@ namespace Poort8.Ishare.Core;
 public interface IAuthenticationService
 {
     string CreateAccessToken(string audience);
-    string CreateTokenWithClaims(string audience, IReadOnlyList<Claim> additionalClaims);
+    string CreateTokenWithClaims(string? audience, IReadOnlyList<Claim> additionalClaims);
     string CreateClientAssertion(string audience, int expSeconds = 30);
     void ValidateAuthorizationHeader(string validIssuer, StringValues authorizationHeader);
     void ValidateAccessToken(string validIssuer, string accessToken);

--- a/Poort8.Ishare.Core/Poort8.Ishare.Core.csproj
+++ b/Poort8.Ishare.Core/Poort8.Ishare.Core.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.18.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.18.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixed the part that the AuthenticationService had an implementation with a nullable variable, but the IAuthenticationService interface had not. Changed the interface to also have it nullable.

Also updated some packages.