### PR TITLE
When certificate password empty, use null

### DIFF
--- a/Poort8.Ishare.Core/CertificateProvider.cs
+++ b/Poort8.Ishare.Core/CertificateProvider.cs
@@ -16,13 +16,13 @@ public class CertificateProvider : ICertificateProvider
         {
             _certificate = new X509Certificate2(
                 Convert.FromBase64String(configuration["Certificate"]),
-                configuration["CertificatePassword"]);
+                string.IsNullOrEmpty(configuration["CertificatePassword"]) ? null : configuration["CertificatePassword"]);
 
             _chainCertificates = new X509Certificate2Collection();
             var chain = configuration["CertificateChain"].Split(',');
             foreach (var certificate in chain)
             {
-                _chainCertificates.Add(new X509Certificate2(Convert.FromBase64String(certificate), configuration["CertificateChainPassword"]));
+                _chainCertificates.Add(new X509Certificate2(Convert.FromBase64String(certificate), string.IsNullOrEmpty(configuration["CertificateChainPassword"]) ? null : configuration["CertificateChainPassword"]));
             }
         }
         catch (Exception)


### PR DESCRIPTION
Fix for exception when password of certificate is empty and an empty string is passed.