### PR TITLE
TEMP: Skip token validation checks on tokens from scheme owner

### DIFF
--- a/Poort8.Ishare.Core/SchemeOwnerService.cs
+++ b/Poort8.Ishare.Core/SchemeOwnerService.cs
@@ -63,7 +63,8 @@ public class SchemeOwnerService : ISchemeOwnerService
 
             if (response is null || response.TrustedListToken is null) { throw new Exception("TrustedList response is null."); }
 
-            _authenticationService.ValidateToken(_configuration["SchemeOwnerIdentifier"], response.TrustedListToken, 30, true);
+            //HACK: Temporarely not validating scheme owner tokens because expired scheme owner certificate
+            //_authenticationService.ValidateToken(_configuration["SchemeOwnerIdentifier"], response.TrustedListToken, 30, true);
 
             var handler = new JwtSecurityTokenHandler { MaximumTokenSizeInBytes = 1024 * 1024 * 2 };
             var trustedListToken = handler.ReadJwtToken(response.TrustedListToken);
@@ -111,7 +112,8 @@ public class SchemeOwnerService : ISchemeOwnerService
 
             if (response is null || response.PartiesToken is null) { throw new Exception("Parties response is null."); }
 
-            _authenticationService.ValidateToken(_configuration["SchemeOwnerIdentifier"], response.PartiesToken, 30, true);
+            //HACK: Temporarely not validating scheme owner tokens because expired scheme owner certificate
+            //_authenticationService.ValidateToken(_configuration["SchemeOwnerIdentifier"], response.PartiesToken, 30, true);
 
             var handler = new JwtSecurityTokenHandler { MaximumTokenSizeInBytes = 1024 * 1024 * 2 };
             var partiesToken = handler.ReadJwtToken(response.PartiesToken);


### PR DESCRIPTION
Since certificate of scheme owner is expired, skip the validation checks on tokens received from the scheme owner