### PR TITLE
Fix the default 'sequence contains no elements' exception thrown

### DIFF
--- a/Poort8.Ishare.Core/SchemeOwnerService.cs
+++ b/Poort8.Ishare.Core/SchemeOwnerService.cs
@@ -130,7 +130,7 @@ public class SchemeOwnerService : ISchemeOwnerService
             if (partiesInfoClaim is null || partiesInfoClaim.Count > 1 || partiesInfoClaim.PartiesInfo is null) { throw new Exception("Received invalid parties info."); }
 
             _logger.LogInformation("Received party info for party {party}", partyId);
-            return partiesInfoClaim.PartiesInfo.First() ?? throw new Exception("Received empty party info list.");
+            return partiesInfoClaim.PartiesInfo.FirstOrDefault() ?? throw new Exception("Received empty party info list.");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Fix the default 'sequence contains no elements' exception thrown with the custom exception already in place