### PR TITLE
Additional checks on parties endpoint response

### DIFF
--- a/Poort8.Ishare.Core.Tests/Poort8.Ishare.Core.Tests.csproj
+++ b/Poort8.Ishare.Core.Tests/Poort8.Ishare.Core.Tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/Poort8.Ishare.Core/Models/PartyInfo.cs
+++ b/Poort8.Ishare.Core/Models/PartyInfo.cs
@@ -14,10 +14,31 @@ public class PartyInfo
     public AdherenceObject? Adherence { get; set; }
 
     [JsonPropertyName("certifications")]
-    public List<Certification>? Certifications { get; set; }
+    public List<Certification>? Certifications { get; set; } //TODO: Remove when migrated to Satellite
 
     [JsonPropertyName("capability_url")]
     public string? CapabilityUrl { get; set; }
+
+    [JsonPropertyName("registrar_id")]
+    public string? RegistrarId { get; set; }
+
+    [JsonPropertyName("spor")]
+    public SporObject? Spor { get; set; }
+
+    [JsonPropertyName("additional_info")]
+    public AdditionalInfoObject? AdditionalInfo { get; set; }
+
+    [JsonPropertyName("agreements")]
+    public List<Agreement>? Agreements { get; set; }
+
+    [JsonPropertyName("certificates")]
+    public List<Certificate>? Certificates { get; set; }
+
+    [JsonPropertyName("roles")]
+    public List<RoleObject>? Roles { get; set; }
+
+    [JsonPropertyName("auth_registries")]
+    public List<AuthRegistry>? AuthRegistries { get; set; }
 
     public class AdherenceObject
     {
@@ -31,7 +52,7 @@ public class PartyInfo
         public DateTime EndDate { get; set; }
     }
 
-    public class Certification
+    public class Certification //TODO: Remove when migrated to Satellite
     {
         [JsonPropertyName("role")]
         public string? Role { get; set; }
@@ -44,5 +65,131 @@ public class PartyInfo
 
         [JsonPropertyName("loa")]
         public int Loa { get; set; }
+    }
+
+    public class SporObject
+    {
+        [JsonPropertyName("signed_request")]
+        public string? SignedRequest { get; set; }
+    }
+
+    public class AdditionalInfoObject
+    {
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("logo")]
+        public string? Logo { get; set; }
+
+        [JsonPropertyName("website")]
+        public string? Website { get; set; }
+
+        [JsonPropertyName("company_phone")]
+        public string? CompanyPhone { get; set; }
+
+        [JsonPropertyName("company_email")]
+        public string? CompanyEmail { get; set; }
+
+        [JsonPropertyName("publicly_publishable")]
+        public string? PubliclyPublishable { get; set; }
+
+        [JsonPropertyName("countriesOfOperation")]
+        public List<object>? CountriesOfOperation { get; set; }
+
+        [JsonPropertyName("sectorIndustry")]
+        public List<object>? SectorIndustry { get; set; }
+
+        [JsonPropertyName("tags")]
+        public string? Tags { get; set; }
+    }
+
+    public class Agreement
+    {
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; set; }
+
+        [JsonPropertyName("sign_date")]
+        public DateTime SignDate { get; set; }
+
+        [JsonPropertyName("expiry_date")]
+        public DateTime ExpiryDate { get; set; }
+
+        [JsonPropertyName("hash_file")]
+        public string? HashFile { get; set; }
+
+        [JsonPropertyName("framework")]
+        public string? Framework { get; set; }
+
+        [JsonPropertyName("dataspace_id")]
+        public string? DataspaceId { get; set; }
+
+        [JsonPropertyName("dataspace_title")]
+        public string? DataspaceTitle { get; set; }
+
+        [JsonPropertyName("complaiancy_verified")]
+        public string? ComplaiancyVerified { get; set; }
+    }
+
+    public class Certificate
+    {
+        [JsonPropertyName("subject_name")]
+        public string? SubjectName { get; set; }
+
+        [JsonPropertyName("certificate_type")]
+        public string? CertificateType { get; set; }
+
+        [JsonPropertyName("enabled_from")]
+        public DateTime EnabledFrom { get; set; }
+
+        [JsonPropertyName("x5c")]
+        public string? X5c { get; set; }
+
+        [JsonPropertyName("x5t#s256")]
+        public string? X5tS256 { get; set; }
+    }
+
+    public class RoleObject
+    {
+        [JsonPropertyName("role")]
+        public string? Role { get; set; }
+
+        [JsonPropertyName("start_date")]
+        public DateTime StartDate { get; set; }
+
+        [JsonPropertyName("end_date")]
+        public DateTime EndDate { get; set; }
+
+        [JsonPropertyName("loa")]
+        public string? LOA { get; set; }
+
+        [JsonPropertyName("complaiancy_verified")]
+        public string? ComplaiancyVerified { get; set; }
+
+        [JsonPropertyName("legal_adherence")]
+        public string? LegalAdherence { get; set; }
+    }
+
+    public class AuthRegistry
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("url")]
+        public string? Url { get; set; }
+
+        [JsonPropertyName("dataspace_id")]
+        public string? DataspaceId { get; set; }
+
+        [JsonPropertyName("dataspace_name")]
+        public string? DataspaceName { get; set; }
     }
 }

--- a/Poort8.Ishare.Core/Poort8.Ishare.Core.csproj
+++ b/Poort8.Ishare.Core/Poort8.Ishare.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.1" />
-    <PackageReference Include="Azure.Identity" Version="1.9.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.0" />
   </ItemGroup>
 
 </Project>

--- a/Poort8.Ishare.Core/SchemeOwnerService.cs
+++ b/Poort8.Ishare.Core/SchemeOwnerService.cs
@@ -130,7 +130,7 @@ public class SchemeOwnerService : ISchemeOwnerService
             if (partiesInfoClaim is null || partiesInfoClaim.Count > 1 || partiesInfoClaim.PartiesInfo is null) { throw new Exception("Received invalid parties info."); }
 
             _logger.LogInformation("Received party info for party {party}", partyId);
-            return partiesInfoClaim.PartiesInfo.First() ?? throw new Exception("Received empty party info list.");
+            return partiesInfoClaim.PartiesInfo.FirstOrDefault() ?? throw new Exception("Received empty party info list.");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Added additional certificate checks on the parties endpoint response when certificates content is returned. Also allow for back-up searching for a party without the certificate subject name when with subject name fails.