### PR TITLE
Add TokenValidationResult checks

### DIFF
--- a/Poort8.Ishare.Core/AuthenticationService.cs
+++ b/Poort8.Ishare.Core/AuthenticationService.cs
@@ -58,6 +58,15 @@ public class AuthenticationService(
             if (tokenReplayAllowed) tokenValidationParameters.ValidateTokenReplay = false;
 
             var validationResult = await handler.ValidateTokenAsync(token, tokenValidationParameters);
+            if (validationResult.IsValid == false)
+            {
+                logger.LogError(
+                    "Token validation error, for valid issuer {validIssuer} and token {token}. With message: {msg}",
+                    validIssuer,
+                    token,
+                    validationResult.Exception?.Message);
+                throw validationResult.Exception ?? new Exception("Token validation failed");
+            }
 
             ValidateIssAndSub(token, validIssuer, validationResult);
             ValidateIatAndExp(token, validIssuer, validationResult);

--- a/Poort8.Ishare.Core/SatelliteService.cs
+++ b/Poort8.Ishare.Core/SatelliteService.cs
@@ -179,7 +179,12 @@ public class SatelliteService(
             RequireSignedTokens = true,
         };
 
-        await handler.ValidateTokenAsync(token, tokenValidationParameters);
+        var validationResult = await handler.ValidateTokenAsync(token, tokenValidationParameters);
+        if (validationResult.IsValid == false)
+        {
+            logger.LogError("Satellite token validation error: {msg}", validationResult.Exception?.Message);
+            throw validationResult.Exception ?? new Exception("Satellite token validation failed");
+        }
 
         return handler.ReadJsonWebToken(token);
     }


### PR DESCRIPTION
## Summary
- inspect TokenValidationResult after calling ValidateTokenAsync
- log and throw when validation fails

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f067e1cd88332b0d46ed3837e325a