### PR TITLE
Fix lifetime check

### DIFF
--- a/Poort8.Ishare.Core.Tests/AuthorizationRegistryServiceTests.cs
+++ b/Poort8.Ishare.Core.Tests/AuthorizationRegistryServiceTests.cs
@@ -87,6 +87,50 @@ public class AuthorizationRegistryServiceTests
     }
 
     [Fact]
+    public void VerifyDelegationEvidencePermit_NotBeforeEqualNow_ShouldPass()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var fakeDelegationEvidence = CreateFakeDelegationEvidence() with
+        {
+            NotBefore = now,
+            NotOnOrAfter = now + 10
+        };
+
+        var permit = _authorizationRegistryService.VerifyDelegationEvidencePermit(
+            fakeDelegationEvidence,
+            fakeDelegationEvidence.PolicyIssuer,
+            fakeDelegationEvidence.Target.AccessSubject,
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Environment.ServiceProviders[0],
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Resource.Type,
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Resource.Identifiers[0],
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Actions[0]);
+
+        permit.Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyDelegationEvidencePermit_NotOnOrAfterEqualNow_ShouldFail()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var fakeDelegationEvidence = CreateFakeDelegationEvidence() with
+        {
+            NotBefore = now - 10,
+            NotOnOrAfter = now
+        };
+
+        var permit = _authorizationRegistryService.VerifyDelegationEvidencePermit(
+            fakeDelegationEvidence,
+            fakeDelegationEvidence.PolicyIssuer,
+            fakeDelegationEvidence.Target.AccessSubject,
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Environment.ServiceProviders[0],
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Resource.Type,
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Resource.Identifiers[0],
+            fakeDelegationEvidence.PolicySets[0].Policies[0].Target.Actions[0]);
+
+        permit.Should().BeFalse();
+    }
+
+    [Fact]
     public void VerifyDelegationEvidencePermit_ValidConditions_ShouldPass()
     {
         var fakeDelegationEvidence = CreateFakeDelegationEvidence(

--- a/Poort8.Ishare.Core/AuthorizationRegistryService.cs
+++ b/Poort8.Ishare.Core/AuthorizationRegistryService.cs
@@ -214,8 +214,8 @@ public class AuthorizationRegistryService(
     private static bool VerifyLifetime(ILogger<AuthorizationRegistryService> logger, DelegationEvidence delegationEvidence)
     {
         var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        if (delegationEvidence.NotBefore >= now ||
-            delegationEvidence.NotOnOrAfter < now)
+        if (delegationEvidence.NotBefore > now ||
+            delegationEvidence.NotOnOrAfter <= now)
         {
             logger.LogWarning("Invalid token lifetime, notBefore {notBefore} or notOnOrAfter {NotOnOrAfter} is not valid: now {now}", delegationEvidence.NotBefore, delegationEvidence.NotOnOrAfter, now);
             return false;


### PR DESCRIPTION
## Summary
- refine lifetime validation logic in AuthorizationRegistryService
- add tests for NotBefore and NotOnOrAfter boundary cases

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f067e9fe48332bb4623a3b967351a